### PR TITLE
Cleaning up plugin.php umc_show_help -- fixes #7

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -93,6 +93,8 @@ function umc_show_help($args = false) {
     $userlevel = umc_get_userlevel($player);
 
     if ($args) { // if show_help is called from another program, we simulate a /help command being issued.
+        $args = array_merge(array('call'), $WSEND['args']);
+    } else {
         $args = $WSEND['args'];
     }
 


### PR DESCRIPTION
PHP syntax checks out.  I'll have to test the help functionality after the merge but I don't believe this will break anything.

The actual fixing here is adding the $command_name variable so that line 144 won't throw an error, but I cleaned up a few other things as well, mostly variable names for clarity, and using the variable $command_name instead of $args[1] in a few places for clarity as well.
