### PR TITLE
Fixed player head command

### DIFF
--- a/websend_inc/hunger.inc.php
+++ b/websend_inc/hunger.inc.php
@@ -645,7 +645,7 @@ function umc_hunger_trophy() {
     umc_echo("[Hunger] {yellow}[$]{gray} You have been charged {yellow}{$HUNGER['trophy_cost']}{gray} uncs.");
     umc_echo("[Hunger] getting head...");
 
-    umc_ws_cmd("ph spawn $victim $player","asConsole");
+    umc_ws_cmd("minecraft:give $player skull 1 3 {SkullOwner:'$victim'}","asConsole");
     umc_echo("[Hunger] {purple}Enjoy this small memento of your victory!");
     umc_log('hunger', 'trophy', "$player got the head of $victim");
 }


### PR DESCRIPTION
Last I was aware of #43 the player head plugin used was broken, I found a native give command that should so the trick.
Used the minecraft: prefix to escape any plugins for give command, should give player head as per command shown here: http://minecraft.gamepedia.com/Mob_head#Player_skins
Hopefully this works.