### PR TITLE
Speed up umc_plg_include

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -27,17 +27,40 @@
 function umc_plg_include() {
     XMPP_ERROR_trace(__FUNCTION__, func_get_args());
     $folder = '/home/minecraft/server/bin/websend_inc';
-    $handle = opendir($folder);
-    if ($handle) {
-        while (false !== ($entry = readdir($handle))) {
-            $start = substr($entry, 0, 1);
-            $ext = substr($entry, -4);
-            if (($start != ".") && ($ext == '.php')) {
-                require_once($folder . "/" . $entry);
-            }
-        }
-        closedir($handle);
-    }
+    
+    // An array of all plugins to be registered and included
+    $plugins = array (
+      'contests',
+      'depositbox',
+      'hardcore',
+      'home',
+      'hunger',
+      'info',
+      'karma',
+      'lot',
+      'lottery',
+      'mail',
+      'mod',
+      'money',
+      'nocheatplus',
+      'others',
+      'potions',
+      'shop',
+      'skyblock',
+      'story',
+      'teamspeak',
+      'trivia',
+      'userlevel',
+      'vanity',
+      'vote',
+      'web',
+      'xp',
+      );
+
+      //Require each plugin.
+      foreach($plugins as $plugin) {
+        require_once($folder . "/" . $plugin . ".inc.php");
+      }
 }
 
 /**


### PR DESCRIPTION
Here's probably the most basic approach to #281 

Instead of scraping a folder, an array could be provided to speed this up. It may be better just having the array in a register.php and include that separately to keep the code clean. It's the most simple approach I can think of. Just remember to register new plugins to the array.